### PR TITLE
Use CGI.escape instead of URI.escape

### DIFF
--- a/lib/lita/handlers/latex.rb
+++ b/lib/lita/handlers/latex.rb
@@ -12,7 +12,7 @@ module Lita
       route %r(\A(?:tex|latex)(?:\s+me)?\s+(.*)\Z), :latex, command: true
 
       def latex(response)
-        expression = URI.escape(response.matches.first.first)
+        expression = CGI.escape(response.matches.first.first)
         response.reply image_url(expression)
       end
 


### PR DESCRIPTION
So that
`tex p_1 = \rho p_0 \Rightarrow p_{n+1} = \rho p_n`
returns
http://chart.apis.google.com/chart?cht=tx&chl=p_1+%3D+%5Crho+p_0+%5CRightarrow+p_%7Bn%2B1%7D+%3D+%5Crho+p_n#.png
![](http://chart.apis.google.com/chart?cht=tx&chl=p_1+%3D+%5Crho+p_0+%5CRightarrow+p_%7Bn%2B1%7D+%3D+%5Crho+p_n#.png)
instead of
http://chart.apis.google.com/chart?cht=tx&chl=p_1%20=%20%5Crho%20p_0%20%5CRightarrow%20p_%7Bn+1%7D%20=%20%5Crho%20p_n#.png
![](http://chart.apis.google.com/chart?cht=tx&chl=p_1%20=%20%5Crho%20p_0%20%5CRightarrow%20p_%7Bn+1%7D%20=%20%5Crho%20p_n#.png)
